### PR TITLE
Cmake integration for mathx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.4.0)
+
+project(mathx CXX)
+
+# Find source files
+file(GLOB SOURCES src/*.cpp)
+
+# Include header files
+include_directories(mathx)
+
+# Create shared library
+add_library(${PROJECT_NAME} SHARED ${SOURCES})
+
+# Install library
+install(TARGETS ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME})
+
+# Install library headers
+file(GLOB HEADERS mathx/*.h)
+install(FILES ${HEADERS} DESTINATION include/${PROJECT_NAME})

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# mathx
+# MATH-X Library
+
+Math-x library comes with various maths functions out of the box.
+
+
+## Install Instruction
+
+###Dependencies
+
+We require the following packages before you try installing the package.
+
+ - A c++ compiler (g++/clang++/msvc++)
+ - Cmake (upwards of version 3.4)
+
+### Instructions
+
+ - Create a build folder inside of main directory.
+
+ ```
+ $ mkdir build && cd build
+ ```
+
+ - Use the cmake command with CMAKE_INSTALL_PREFIX to select the directory to install to (not using this command will defaul to install directories)
+
+ ```
+ $ cmake -DCMAKE_INSTALL_PREFIX=/path/to/install
+ ```
+
+ For example, one can type:
+
+ ```
+ $ cmake -DCMAKE_INSTALL_PREFIX=/home/user/mathx_build/
+ ```

--- a/src/calculus.cpp
+++ b/src/calculus.cpp
@@ -10,6 +10,8 @@
 #define INF 1e12
 
 #include <iostream>
+#include <climits>
+#include <cstdlib>
 
 namespace mathx {
 
@@ -17,7 +19,7 @@ namespace mathx {
     long double differentiate(long double (*fn)(long double), long double x) {
         long double rhd = (fn(x + dx) - fn(x)) / dx;
         long double lhd = (fn(x) - fn(x - dx)) / dx;
-        if(fabs(rhd - lhd) < (dx)*100)
+        if(std::abs(rhd - lhd) < (dx)*100)
             return (rhd + lhd)/2;
         else {
             std::cerr << "Then given function is not differentiable at " << x << '\n';


### PR DESCRIPTION
This pr adds a very basic `cmake` integration to `mathx` project. I will implement a full tree cmake later. As of now, one can simply use `-I/path/to/include` `-L/path/to/lib` `-l/path/to/so` (it's capital i in include and small l in so) compiler flags and linker flags respectively to generate an executable. I'll add pkg-config support later too.
This is a bare bones cmake integration to make things working again.