### PR TITLE
Adds pkg-config to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,17 @@ project(mathx CXX)
 # Include header files
 include_directories(mathx)
 
-add_subdirectory(src)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake")
+
+include(mathx_GeneratePackage)
+
+# add_subdirectory(src)
+
+# Find source files
+file(GLOB SOURCES src/*.cpp)
+
+# Create shared library
+add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
 # Install library
 install(TARGETS ${PROJECT_NAME} DESTINATION lib)

--- a/cmake/mathx_GeneratePackage.cmake
+++ b/cmake/mathx_GeneratePackage.cmake
@@ -1,0 +1,19 @@
+include(CMakePackageConfigHelpers)
+
+# Get the include directories we need ...
+get_directory_property(_INCLUDE_DIRS INCLUDE_DIRECTORIES)
+
+set(MATHX_CONF_PREFIX ${CMAKE_INSTALL_PREFIX}/lib/libmathx.so)
+set(CXX_FLAGS CMAKE_CXX_FLAGS)
+
+configure_file(cmake/templates/mathx.pc.in
+  "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/mathx.pc"
+  ESCAPE_QUOTES @ONLY)
+
+
+install(
+  FILES
+    "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/mathx.pc"
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig
+  COMPONENT pkgconfig
+)

--- a/cmake/templates/mathx.pc.in
+++ b/cmake/templates/mathx.pc.in
@@ -1,0 +1,10 @@
+prefix=@MATHX_CONF_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${exec_prefix}/include
+
+Name: mathx
+Description:
+Version: 1.0
+Libs: @CXX_FLAG@ -L${libdir} @MATHX_CONF_PREFIX@
+Cflags: @CXX_FLAG@


### PR DESCRIPTION
Now the user needs to upgrade the `PKG_CONFIG_PATH` and invoke the `pkg-config` to build applications using `pkg-config`.

Now we officially discourage using makefiles.